### PR TITLE
Reduce captcha patch and bugs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 dWdnY2Y6Ly9iY3JhLmZjYmd2c2wucGJ6L2dlbnB4LzVwc2tIZ1B4Y3hQVkVlWGxxVVhGb1kgcm90MTM= </br>
 
-<h1 align="center">OwO Farm Bot Stable V0.0.2(BETA)</h1>
+<h1 align="center">OwO Farm Bot Stable V0.0.3(BETA)</h1>
 <p align="center">
 
 [![Total Views](https://hits.sh/github.com/Mid0aria/owofarmbot_stable.svg?view=today-total&label=Repo%20Today/Total%20Views&color=770ca1&labelColor=007ec6)](https://github.com/Mid0aria/owofarmbot_stable)
@@ -48,7 +48,7 @@ To get auth key, join the Discord server [here](https://discord.gg/WzYXVbXt6C), 
 
 -   Use of this farm bot may lead to actions being taken against your OwO profile and/or your Discord account. We are not responsible for them.
 -   Discord may restart as a result of discord RPC overload.
--   DO NOT USE ONE CHANNEL FOR TWO ACCOUNTS, USE IT FOR 1 ACCOUNT ONLY.
+-   FARM, QUEST AND GAMBLE NEED TO PLACE IN DIFFERENT CHANNEL. That mean if you use all of them, you need three different channel. And if you use extra token, that will be six.
 
 ## 👑・Features
 
@@ -172,8 +172,11 @@ To get auth key, join the Discord server [here](https://discord.gg/WzYXVbXt6C), 
         "discordrpc": false, / true or false (boolean)
         "chatfeedback": true, / true or false (boolean)
         "autophrases": true, / true or false (boolean)
-        "newlog": true, / a log with a table for controlling, will remove old log
-        "loglength": 20, / how many lines of log at one moment (only affect when newlog is true)
+        "logging": {
+            "newlog": true, / a log with a table for controlling, will remove old log
+            "loglength": 20, / how many lines of log at one moment (only affect when newlog is true)
+            "showlogbeforeexit": false / show a full log when user click ctrl + c (only affect when newlog is true)
+        },
         "checklist": {
             "types": {
                 "daily": true, / true or false (boolean)
@@ -209,7 +212,6 @@ To get auth key, join the Discord server [here](https://discord.gg/WzYXVbXt6C), 
         }
     },
     "animals": {
-        "interval": 610000, / interval for commands
         "type": {
             "sell": false, / true or false (boolean)
             "sacrifice": false / true or false (boolean)
@@ -229,6 +231,32 @@ To get auth key, join the Discord server [here](https://discord.gg/WzYXVbXt6C), 
             "fabled": false, / true or false (boolean)
             "special": false, / true or false (boolean)
             "hidden": false / true or false (boolean)
+        }
+    },
+    "interval": { / interval for commands (milisecond)
+        "hunt": {
+            "max": 32000,
+            "min": 16000
+        },
+        "battle": {
+            "max": 32000,
+            "min": 16000
+        },
+        "pray": {
+            "max": 332000,
+            "min": 316000
+        },
+        "coinflip": {
+            "max": 32000,
+            "min": 16000
+        },
+        "slot": {
+            "max": 32000,
+            "min": 16000
+        },
+        "animals": {
+            "max": 661000,
+            "min": 610000
         }
     }
 }

--- a/bot.js
+++ b/bot.js
@@ -364,7 +364,8 @@ function verifyconfig() {
         config.settings.gamble.coinflip.default_amount <= 0
     )) showerrcoziamlazy("Invalid gamble amount!");
     
-    let clients = [client, extrac];
+    let clients = [client];
+    if (config.extra.enable) clients.push(extrac);
     for (const client of clients) {
         if (client.basic.maximum_gem_rarity.length > 0) {
             switch (client.basic.maximum_gem_rarity.toLowerCase()) {

--- a/bot.js
+++ b/bot.js
@@ -61,7 +61,8 @@ let owofarmbot_stable = {
         usedevent: false,
         usedcookie: false,
         animaltype: "",
-        isready: false
+        isready: false,
+        started: false
     },
 };
 
@@ -102,7 +103,8 @@ let coolVariableName = {
         usedevent: false,
         usedcookie: false,
         animaltype: "",
-        isready: false
+        isready: false,
+        started: false
     },
 };
 
@@ -349,9 +351,6 @@ function verifyconfig() {
         )
         showerrcoziamlazy("Curse and pray cannot be turn on at the same time!");
     
-    if (config.animals.interval && config.animals.interval < 16000)
-        showerrcoziamlazy("Animals interval is too low!");
-    
     if ((
         config.main.commands.gamble.coinflip ||
         config.main.commands.gamble.slot ||
@@ -470,7 +469,32 @@ function verifyconfig() {
                 showerrcoziamlazy("Sell and sacrifice cannot be turn on at the same time!");
             }
         }
-    
+        
+    const verifyInterval = (type, minValue, minDefault, maxValue, maxDefault) => {
+        if (minValue < minDefault) {
+            client.logger.warn("Bot", "Config", `${type} min interval is too low, resetting to default!`);
+            config.interval[type].min = minDefault;
+        }
+        if (maxValue < minDefault || maxValue < minValue) {
+            client.logger.warn("Bot", "Config", `${type} max interval is too low or less than min, resetting to default!`);
+            config.interval[type].max = maxDefault;
+        }
+    };
+
+    const intervals = ["hunt", "battle", "pray", "coinflip", "slot", "animals"];
+    let missingValue = intervals.some(type => !config.interval[type].min || !config.interval[type].max);
+
+    if (missingValue) {
+        showerrcoziamlazy("Interval cannot be null!");
+    } else {
+        verifyInterval("hunt", config.interval.hunt.min, 16000, config.interval.hunt.max, 32000);
+        verifyInterval("battle", config.interval.battle.min, 16000, config.interval.battle.max, 32000);
+        verifyInterval("pray", config.interval.pray.min, 316000, config.interval.pray.max, 332000);
+        verifyInterval("coinflip", config.interval.coinflip.min, 16000, config.interval.coinflip.max, 32000);
+        verifyInterval("slot", config.interval.slot.min, 16000, config.interval.slot.max, 32000);
+        verifyInterval("animals", config.interval.animals.min, 610000, config.interval.animals.max, 661000);
+    }
+    //does it change? idk!
     function showerrcoziamlazy(err) {
         client.logger.alert(
             "Bot",

--- a/bot.js
+++ b/bot.js
@@ -325,6 +325,8 @@ function verifyconfig() {
         "Verifing config... Please wait...");
     if ((config.main.token == config.extra.token) && config.main.token.length > 0)
         showerrcoziamlazy("Main token is same as extra token!");
+    if (config.extra.enable && config.extra.token.length == 0)
+        showerrcoziamlazy("Extra token enabled but no token found");
     
     let vars = [
         config.main.commandschannelid,
@@ -338,9 +340,10 @@ function verifyconfig() {
     for (let i = 0; i < vars.length; i++) {
         for (let j = i + 1; j < vars.length; j++) {
             if ((vars[i] == vars[j]) && vars[i].length > 0) {
-                showerrcoziamlazy(`${vars[i]} is equal to ${vars[j]}`);
+                showerrcoziamlazy(`There are some duplicate channel id!`);
                 console.log("Please use three different channel for one tokentype for best efficiency!");
-                console.log("That mean if you use both main and extra, you need six channel!");
+                console.log("That mean if you use both main and extra, and farm, quest and gamble, you need six channel!");
+                break;
             }
         }
     }

--- a/bot.js
+++ b/bot.js
@@ -487,11 +487,11 @@ function verifyconfig() {
     if (missingValue) {
         showerrcoziamlazy("Interval cannot be null!");
     } else {
-        verifyInterval("hunt", config.interval.hunt.min, 16000, config.interval.hunt.max, 32000);
-        verifyInterval("battle", config.interval.battle.min, 16000, config.interval.battle.max, 32000);
+        verifyInterval("hunt", config.interval.hunt.min, 12000, config.interval.hunt.max, 16000);
+        verifyInterval("battle", config.interval.battle.min, 12000, config.interval.battle.max, 16000);
         verifyInterval("pray", config.interval.pray.min, 316000, config.interval.pray.max, 332000);
-        verifyInterval("coinflip", config.interval.coinflip.min, 16000, config.interval.coinflip.max, 32000);
-        verifyInterval("slot", config.interval.slot.min, 16000, config.interval.slot.max, 32000);
+        verifyInterval("coinflip", config.interval.coinflip.min, 12000, config.interval.coinflip.max, 16000);
+        verifyInterval("slot", config.interval.slot.min, 12000, config.interval.slot.max, 16000);
         verifyInterval("animals", config.interval.animals.min, 610000, config.interval.animals.max, 661000);
     }
     //does it change? idk!

--- a/commands/start.js
+++ b/commands/start.js
@@ -10,15 +10,24 @@ module.exports = {
             client.global.paused = false;
             client.rpc("update");
             await message.delete();
-            if (client.config.settings.chatfeedback) {
-                await message.channel.send({
-                    content: "BOT started have fun ;)",
-                });
-            }
+            if (!client.global.temp.started) {
+                client.global.temp.started = true;
+                if (client.config.settings.chatfeedback) {
+                    await message.channel.send({
+                        content: "BOT started have fun ;)",
+                    });
+                }
 
-            setTimeout(() => {
-                require("../utils/mainHandler.js")(client, message);
-            }, 1000);
+                setTimeout(() => {
+                    require("../utils/mainHandler.js")(client, message);
+                }, 1000);
+            } else {
+                if (client.config.settings.chatfeedback) {
+                    await message.channel.send({
+                        content: "Restarted BOT after a pause :3",
+                    });
+                }
+            }
         } else {
             await message.delete();
             if (client.config.settings.chatfeedback) {

--- a/config.json
+++ b/config.json
@@ -59,7 +59,7 @@
         "logging": {
             "newlog": true,
             "loglength": 20,
-            "showlogbeforeexit": true
+            "showlogbeforeexit": false
         },
         "checklist": {
             "types": {

--- a/config.json
+++ b/config.json
@@ -56,8 +56,11 @@
         "discordrpc": false,
         "chatfeedback": true,
         "autophrases": true,
-        "newlog": false,
-        "loglength": 20,
+        "logging": {
+            "newlog": true,
+            "loglength": 20,
+            "showlogbeforeexit": true
+        },
         "checklist": {
             "types": {
                 "daily": true,
@@ -93,7 +96,6 @@
         }
     },
     "animals": {
-        "interval": 610000,
         "type": {
             "sell": false,
             "sacrifice": false
@@ -113,6 +115,32 @@
             "fabled": false,
             "special": false,
             "hidden": false
+        }
+    },
+    "interval": {
+        "hunt": {
+            "max": 32000,
+            "min": 16000
+        },
+        "battle": {
+            "max": 32000,
+            "min": 16000
+        },
+        "pray": {
+            "max": 332000,
+            "min": 316000
+        },
+        "coinflip": {
+            "max": 32000,
+            "min": 16000
+        },
+        "slot": {
+            "max": 32000,
+            "min": 16000
+        },
+        "animals": {
+            "max": 661000,
+            "min": 610000
         }
     }
 }

--- a/config.json
+++ b/config.json
@@ -26,7 +26,7 @@
         "maximum_gem_rarity": "Mythical"
     },
     "extra": {
-        "enable": true,
+        "enable": false,
         "token": "",
         "userid": "",
         "commandschannelid": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "owofarmbot_stable",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Discord OwO farm bot stable with CAPTCHA(BAN) protection",
     "main": "bot.js",
     "repository": {

--- a/utils/function/farm.js
+++ b/utils/function/farm.js
@@ -1,4 +1,5 @@
 const commandrandomizer = (arr) => arr[Math.floor(Math.random() * arr.length)];
+const getrand = (min, max) => Math.random() * (max - min) + min;
 
 module.exports = async (client, message) => {
     let channel = client.channels.cache.get(client.basic.commandschannelid);
@@ -18,161 +19,174 @@ module.exports = async (client, message) => {
 }
 
 async function hunt(client, channel) {
-    const triggerhunt = async () => {
-        if (
-            client.global.paused ||
-            client.global.captchadetected ||
-            client.global.use ||
-            client.global.inventory ||
-            client.global.checklist ||
-            client.global.hunt
-        )
-            return;
-        if (client.global.battle) await client.delay(1500);
-        client.global.hunt = true;
-        let id;
-        await channel
-            .send({
-                content: `${commandrandomizer([
-                    "owo",
-                    client.config.settings.owoprefix,
-                ])} ${commandrandomizer(["h", "hunt"])}`,
-            })
-            .then(async (huntmsg) => {
-                id = huntmsg.id;
-                client.global.total.hunt++;
-                client.logger.info(
-                    "Farm",
-                    "Hunt",
-                    `Total Hunt: ${client.global.total.hunt}`
-                );
-                if (client.config.settings.inventory.use.gems) {
-                    let message = await getMessage();
-                    async function getMessage() {
-                        return new Promise((resolve) => {
-                            const filter = (msg) =>
-                                (msg.content.includes("and caught a") || msg.content.includes("You found:")) &&
-                                msg.author.id === "408785106942164992" &&
-                                msg.channel.id === channel.id &&
-                                msg.id.localeCompare(id) > 0;
-                                
-                            const listener = (msg) => {
+    while (
+        client.global.paused ||
+        client.global.captchadetected ||
+        client.global.use ||
+        client.global.inventory ||
+        client.global.checklist ||
+        client.global.hunt
+    ) {
+        await client.delay(16000);
+    }
+    channel.sendTyping();
+    if (client.global.battle) await client.delay(1500);
+    client.global.hunt = true;
+    let interval = getrand(
+        client.config.interval.hunt.min,
+        client.config.interval.hunt.max);
+    let id;
+    await channel
+        .send({
+            content: `${commandrandomizer([
+                "owo",
+                client.config.settings.owoprefix,
+            ])} ${commandrandomizer(["h", "hunt"])}`,
+        })
+        .then(async (huntmsg) => {
+            id = huntmsg.id;
+            client.global.total.hunt++;
+            client.logger.info(
+                "Farm",
+                "Hunt",
+                `Total Hunt: ${client.global.total.hunt}`
+            );
+            if (client.config.settings.inventory.use.gems) {
+                let message = await getMessage();
+                async function getMessage() {
+                    return new Promise((resolve) => {
+                        const filter = (msg) =>
+                            (msg.content.includes("and caught a") || msg.content.includes("You found:")) &&
+                            msg.author.id === "408785106942164992" &&
+                            msg.channel.id === channel.id &&
+                            msg.id.localeCompare(id) > 0;
+                            
+                        const listener = (msg) => {
+                            if (filter(msg)) {
+                                clearTimeout(timer);
+                                client.off("messageCreate", listener);
+                                resolve(msg);
+                            }
+                        };
+                        
+                        const timer = setTimeout(() => {
+                            client.off("messageCreate", listener);
+                            const collector = channel.createMessageCollector({ filter, time: 6100});
+                            collector.on("collect", (msg) => {
                                 if (filter(msg)) {
-                                    clearTimeout(timer);
-                                    client.off("messageCreate", listener);
+                                    collector.stop();
                                     resolve(msg);
                                 }
-                            };
-                            
-                            const timer = setTimeout(() => {
-                                client.off("messageCreate", listener);
-                                const collector = channel.createMessageCollector({ filter, time: 6100});
-                                collector.on("collect", (msg) => {
-                                    if (filter(msg)) {
-                                        collector.stop();
-                                        resolve(msg);
-                                    }
-                                });
-                                collector.on("end", () => resolve(null));
-                            }, 6100);
+                            });
+                            collector.on("end", () => resolve(null));
+                        }, 6100);
 
-                            client.on("messageCreate", listener);
-                        });
+                        client.on("messageCreate", listener);
+                    });
+                }
+                
+                if (message == null) {
+                    client.global.hunt = false;
+                    client.logger.alert(
+                        "Farm",
+                        "Hunt",
+                        "Cannot found hunt result!");
+                    setTimeout(() => {
+                        hunt(client, channel);
+                    }, interval);
+                    return;
+                }
+                
+                let huntmsgcontent = message.content;
+                client.global.gems.need = [];
+                client.global.gems.use = "";
+                if (huntmsgcontent) {
+                    let requiredGems = ["gem1", "gem3", "gem4"];
+                    requiredGems.forEach((gem) => {
+                        if (!huntmsgcontent.includes(gem)) {
+                            client.global.gems.need.push(gem);
+                        }
+                    });
+                    
+                    if (client.global.gems.isevent) {
+                        if (!huntmsgcontent.includes("star")) {
+                            if (!client.global.temp.usedevent) {
+                                client.global.gems.need.push("star");
+                                client.global.temp.usedevent = true;
+                            } else {
+                                client.global.gems.isevent = false;
+                                client.logger.info("Farm", "Hunt", "Event not found");
+                            }
+                        } else client.global.temp.usedevent = false;
                     }
                     
-                    if (message == null) {
-                        client.global.hunt = false;
-                        client.logger.alert(
+                    if (client.global.gems.need.length > 0) {
+                        client.logger.warn(
                             "Farm",
                             "Hunt",
-                            "Cannot found hunt result!");
-                        return;
-                    }
-                    
-                    let huntmsgcontent = message.content;
-                    client.global.gems.need = [];
-                    client.global.gems.use = "";
-                    if (huntmsgcontent) {
-                        let requiredGems = ["gem1", "gem3", "gem4"];
-                        requiredGems.forEach((gem) => {
-                            if (!huntmsgcontent.includes(gem)) {
-                                client.global.gems.need.push(gem);
-                            }
-                        });
+                            `Missing gems: ${client.global.gems.need}`
+                        );
                         
-                        if (client.global.gems.isevent) {
-                            if (!huntmsgcontent.includes("star")) {
-                                if (!client.global.temp.usedevent) {
-                                    client.global.gems.need.push("star");
-                                    client.global.temp.usedevent = true;
-                                } else {
-                                    client.global.gems.isevent = false;
-                                    client.logger.info("Farm", "Hunt", "Event not found");
-                                }
-                            } else client.global.temp.usedevent = false;
-                        }
-                        
-                        if (client.global.gems.need.length > 0) {
-                            client.logger.warn(
-                                "Farm",
-                                "Hunt",
-                                `Missing gems: ${client.global.gems.need}`
-                            );
-                            
-                            if (client.basic.commands.inventory) {
-                                await client.delay(2000);
-                                await require("./inventory.js")(client, message);
-                            } //put it here to only check inv when missing gem
-                        }
+                        if (client.basic.commands.inventory) {
+                            setTimeout(() => {
+                                require("./inventory.js")(client, message);
+                            }, 2000);
+                        } //put it here to only check inv when missing gem
                     }
                 }
-                await client.delay(1000);
-                client.global.hunt = false;
-            });
-        if (client.config.settings.autophrases) {
-            await client.delay(4000);
-            await elaina2(client, channel);
-        }
-        await client.delay(10500);
+            }
+            await client.delay(1000);
+            client.global.hunt = false;
+            
+            setTimeout(() => {
+                hunt(client, channel);
+            }, interval);
+        });
+    if (client.config.settings.autophrases) {
+        setTimeout(() => {
+            elaina2(client, channel);
+        }, 4000);
     }
-    
-    triggerhunt(); //same but shorter ig?
-    setInterval(triggerhunt, 16200);
 }
 
 async function battle(client, channel) {
-    const triggerbattle = async () => {
-        if (
-            client.global.paused ||
-            client.global.captchadetected ||
-            client.global.use ||
-            client.global.checklist ||
-            client.global.inventory ||
-            client.global.battle
-        )
-            return;
-        if (client.global.hunt) await client.delay(1500);
-        client.global.battle = true;
-        await channel
-            .send({
-                content: `${commandrandomizer([
-                    "owo",
-                    client.config.settings.owoprefix,
-                ])} ${commandrandomizer(["b", "battle"])}`,
-            })
-            .then(() => {
-                client.global.total.battle++;
-                client.logger.info(
-                    "Farm",
-                    "Battle",
-                    `Total Battle: ${client.global.total.battle}`
-                );
-                client.global.battle = false;
-            });
+    while (
+        client.global.paused ||
+        client.global.captchadetected ||
+        client.global.use ||
+        client.global.checklist ||
+        client.global.inventory ||
+        client.global.battle ||
+        !client.basic.commands.battle // prevent quest confiict
+    ) {
+        await client.delay(16000);
     }
+    channel.sendTyping();
+    if (client.global.hunt) await client.delay(1500);
+    client.global.battle = true;
+    let interval = getrand(
+        client.config.interval.battle.min,
+        client.config.interval.battle.max);
+    await channel
+        .send({
+            content: `${commandrandomizer([
+                "owo",
+                client.config.settings.owoprefix,
+            ])} ${commandrandomizer(["b", "battle"])}`,
+        })
+        .then(() => {
+            client.global.total.battle++;
+            client.logger.info(
+                "Farm",
+                "Battle",
+                `Total Battle: ${client.global.total.battle}`
+            );
+            client.global.battle = false;
+        });
     
-    triggerbattle();
-    setInterval(triggerbattle, 19000);
+    setTimeout(() => {
+        battle(client, channel);
+    }, interval);
 }
 
 async function elaina2(client, channel) {
@@ -191,7 +205,7 @@ async function elaina2(client, channel) {
         let result = Math.floor(Math.random() * phrases.length);
         let ilu = phrases[result];
 
-        // await channel.sendTyping();
+        channel.sendTyping();
         await channel.send({ content: ilu });
         client.logger.info("Farm", "Phrases", `Successfuly Sended`);
     });

--- a/utils/function/gamble.js
+++ b/utils/function/gamble.js
@@ -1,4 +1,5 @@
 const commandrandomizer = (arr) => arr[Math.floor(Math.random() * arr.length)];
+const getrand = (min, max) => Math.random() * (max - min) + min;
 
 module.exports = async (client, message) => {
     if (client.config.settings.owoprefix.length <= 0) {
@@ -21,22 +22,22 @@ async function coinflip(client, channel) {
     let currentBet = defaultBet;
     let maxBet = client.config.settings.gamble.coinflip.max_amount;
     let multiplier = client.config.settings.gamble.coinflip.multiplier;
-    let coinfliping = false;
 
     smol();
     async function smol() {
-        if (
+        while (
             client.global.captchadetected ||
-            coinfliping ||
             client.global.paused ||
             client.global.inventory ||
             client.global.checklist
         ) {
-            setTimeout(smol, 16000);
-            return;
+            await client.delay(16000);
         }
 
-        coinfliping = true;
+        channel.sendTyping();
+        let interval = getrand(
+            client.config.interval.coinflip.min,
+            client.config.interval.coinflip.max);
         const content = commandrandomizer(["owo", client.config.settings.owoprefix]) +
                            commandrandomizer(["coinflip", "cf"]) + " " +
                            commandrandomizer(["heads", "tails", "h", "t"]) + " " + currentBet;
@@ -49,65 +50,72 @@ async function coinflip(client, channel) {
                 "Farm",
                 "Coinflip",
                 `Betting: ${currentBet}. Total time: ${client.global.gamble.coinflip}`);
-        });
 
-        const updateCFListener = (oldMsg, newMsg) => {
-            if (newMsg.channel.id !== channel.id ||
-                newMsg.author.id !== "408785106942164992" ||
-                newMsg.id.localeCompare(id) < 0) return;
-            const isWin = newMsg.content.includes("and you won");
-            const isLoss = newMsg.content.includes("and you lost");
+            const updateCFListener = (oldMsg, newMsg) => {
+                if (newMsg.channel.id !== channel.id ||
+                    newMsg.author.id !== "408785106942164992" ||
+                    newMsg.id.localeCompare(id) < 0) return;
+                const isWin = newMsg.content.includes("and you won");
+                const isLoss = newMsg.content.includes("and you lost");
 
-            if ((isWin || isLoss) &&
-                (
-                !oldMsg.content.includes("and you won") &&
-                !oldMsg.content.includes("and you lost")
-                )) {
-                client.global.gamble.cowoncywon += isWin ? currentBet : -currentBet;
-                client.logger.info("Farm", "Coinflip", `${isWin ? "Won" : "Lost"} ${currentBet}!`);
-                currentBet = isWin ? defaultBet : Math.min(Math.round(currentBet * multiplier), maxBet);
-
-                client.off('messageUpdate', updateCFListener);
-                coinfliping = false;
-                setTimeout(smol, 16000);
-            }
-        };
-
-        const startCollector = () => {
-            const filter = msg =>
-                msg.author.id === "408785106942164992" &&
-                msg.id.localeCompare(id) > 0 &&
-                msg.content.includes("and chose");
-            const collector = channel.createMessageCollector({ filter, time: 10000 });
-
-            collector.on("collect", (msg) => {
-                const isWin = msg.content.includes("and you won");
-                const isLoss = msg.content.includes("and you lost");
-
-                if (isWin || isLoss) {
+                if ((isWin || isLoss) &&
+                    (
+                    !oldMsg.content.includes("and you won") &&
+                    !oldMsg.content.includes("and you lost")
+                    )) {
                     client.global.gamble.cowoncywon += isWin ? currentBet : -currentBet;
                     client.logger.info("Farm", "Coinflip", `${isWin ? "Won" : "Lost"} ${currentBet}!`);
                     currentBet = isWin ? defaultBet : Math.min(Math.round(currentBet * multiplier), maxBet);
-                    coinfliping = false;
-                } else {
-                    client.global.gamble.coinflip--;
-                    client.logger.info("Farm", "Coinflip", "Failed to gamble!");
+
+                    client.off('messageUpdate', updateCFListener);
+                    clearTimeout(doublecheck);
+
+                    setTimeout(() => {
+                        smol();
+                    }, interval);
                 }
+            };
 
-                collector.stop();
-            });
+            const startCollector = () => {
+                const filter = (msg) =>
+                    msg.author.id === "408785106942164992" &&
+                    msg.id.localeCompare(id) > 0 &&
+                    msg.content.includes("and chose");
+                const collector = channel.createMessageCollector({ filter, time: 10000 });
 
-            collector.on("end", () => setTimeout(smol, 16000));
-        };
+                collector.on("collect", (msg) => {
+                    const isWin = msg.content.includes("and you won");
+                    const isLoss = msg.content.includes("and you lost");
 
-        setTimeout(() => {
-            if (coinfliping) {
+                    if (isWin || isLoss) {
+                        client.global.gamble.cowoncywon += isWin ? currentBet : -currentBet;
+                        client.logger.info("Farm", "Coinflip", `${isWin ? "Won" : "Lost"} ${currentBet}!`);
+                        currentBet = isWin ? defaultBet : Math.min(Math.round(currentBet * multiplier), maxBet);
+                    }
+
+                    setTimeout(() => {
+                        smol();
+                    }, interval);
+                });
+                
+                collector.on("end", (collected) => {
+                    if (collected.size == 0) {
+                        client.global.gamble.coinflip--;
+                        client.logger.info("Farm", "Coinflip", "Failed to gamble!");
+                        setTimeout(() => {
+                            smol();
+                        }, interval);
+                    }
+                });
+            };
+
+            const doublecheck = setTimeout(() => {
                 client.off('messageUpdate', updateCFListener);
                 startCollector();
-            }
-        }, 10000);
+            }, 10000);
 
-        client.on('messageUpdate', updateCFListener);
+            client.on('messageUpdate', updateCFListener);
+        });
     }
 }
 
@@ -116,22 +124,22 @@ function slot(client, channel) {
     let currentBet = defaultBet;
     let maxBet = client.config.settings.gamble.slot.max_amount;
     let multiplier = client.config.settings.gamble.slot.multiplier;
-    let sloting = false;
 
     smol();
     async function smol() {
-        if (
+        while (
             client.global.captchadetected ||
-            sloting ||
             client.global.paused ||
             client.global.inventory ||
             client.global.checklist
         ) {
-            setTimeout(smol, 16000);
-            return;
+            await client.delay(16000);
         }
 
-        sloting = true;
+        channel.sendTyping();
+        let interval = getrand(
+            client.config.interval.slot.min,
+            client.config.interval.slot.max);
         const content = commandrandomizer(["owo", client.config.settings.owoprefix]) +
                         commandrandomizer(["slots", "s"]) + " " + currentBet;
 
@@ -143,76 +151,74 @@ function slot(client, channel) {
                 "Farm",
                 "Slot",
                 `Betting: ${currentBet}. Total time: ${client.global.gamble.slot}`);
-        });
 
-        const updateSlotListener = (oldMsg, newMsg) => {
-            if (newMsg.channel.id !== channel.id ||
-                newMsg.author.id !== "408785106942164992" ||
-                newMsg.id.localeCompare(id) < 0) return;
-            
-            const isWin = newMsg.content.includes("and won") && !newMsg.content.includes("nothing...");
-            const isLoss = newMsg.content.includes("and won nothing...");
-            
-            if (isWin || isLoss) {
-                if (isWin) {
-                    const match = newMsg.content.match(/and won <:\w+:\d+> (\d[\d,]*)/);
-                    let won = Number(match[1].replace(/,/g, '')) - currentBet;
-                    client.global.gamble.cowoncywon += won;
-                    client.logger.info("Farm", "Slot", `Won ${won}!`);
-                    currentBet = defaultBet;
-                } else if (isLoss) {
-                    client.global.gamble.cowoncywon -= currentBet;
-                    client.logger.info("Farm", "Slot", `Lost ${currentBet}!`);
-                    currentBet = Math.min(Math.round(currentBet * multiplier), maxBet);
-                }
+            const updateSlotListener = (oldMsg, newMsg) => {
+                if (newMsg.channel.id !== channel.id ||
+                    newMsg.author.id !== "408785106942164992" ||
+                    newMsg.id.localeCompare(id) < 0) return;
                 
-                client.off('messageUpdate', updateSlotListener);
-                sloting = false;
-                setTimeout(smol, 18000);
-            }
-        };
-
-        const startCollector = () => {
-            const filter = msg => msg.author.id === "408785106942164992" && msg.id > id && msg.content.includes("SLOTS");
-            const collector = channel.createMessageCollector({ filter, time: 10000 });
-
-            collector.on("collect", (msg) => {
-                const isWin = msg.content.includes("and won") && !msg.content.includes("nothing...");
-                const isLoss = msg.content.includes("and won nothing...");
-
+                const isWin = newMsg.content.includes("and won") && !newMsg.content.includes("nothing...");
+                const isLoss = newMsg.content.includes("and won nothing...");
+                
                 if (isWin || isLoss) {
                     if (isWin) {
-                        const match = msg.content.match(/and won <:\w+:\d+> (\d[\d,]*)/);
+                        const match = newMsg.content.match(/and won <:\w+:\d+> (\d[\d,]*)/);
                         let won = Number(match[1].replace(/,/g, '')) - currentBet;
                         client.global.gamble.cowoncywon += won;
                         client.logger.info("Farm", "Slot", `Won ${won}!`);
                         currentBet = defaultBet;
-                    } else {
+                    } else if (isLoss) {
                         client.global.gamble.cowoncywon -= currentBet;
                         client.logger.info("Farm", "Slot", `Lost ${currentBet}!`);
                         currentBet = Math.min(Math.round(currentBet * multiplier), maxBet);
                     }
                     
-                    sloting = false;
-                } else {
-                    client.global.gamble.slot--;
-                    client.logger.info("Farm", "Slot", "Failed to gamble!");
-                    sloting = false;
+                    client.off('messageUpdate', updateSlotListener);
+                    clearTimeout(doublecheck);
+                    setTimeout(() => {
+                        smol();
+                    }, interval);
                 }
+            };
 
-                collector.stop();
-            });
+            const startCollector = () => {
+                const filter = (msg) => msg.author.id === "408785106942164992" && msg.id.localeCompare(id) > 0 && msg.content.includes("SLOTS");
+                const collector = channel.createMessageCollector({ filter, time: 10000 });
 
-            collector.on("end", () => setTimeout(smol, 16000));
-        };
+                collector.on("collect", (msg) => {
+                    if (msg.content.includes("and won") && !msg.content.includes("nothing...")) {
+                        const match = msg.content.match(/and won <:\w+:\d+> (\d[\d,]*)/);
+                        let won = Number(match[1].replace(/,/g, '')) - currentBet;
+                        client.global.gamble.cowoncywon += won;
+                        client.logger.info("Farm", "Slot", `Won ${won}!`);
+                        currentBet = defaultBet;
+                    } else if (msg.content.includes("and won nothing...")) {
+                        client.global.gamble.cowoncywon -= currentBet;
+                        client.logger.info("Farm", "Slot", `Lost ${currentBet}!`);
+                        currentBet = Math.min(Math.round(currentBet * multiplier), maxBet);
+                    }
+                    setTimeout(() => {
+                        smol();
+                    }, interval);
+                });
+                
+                collector.on("end", (collected) => {
+                    if (collected.size == 0) {
+                        client.global.gamble.slot--;
+                        client.logger.info("Farm", "Slot", "Failed to gamble!");
+                        setTimeout(() => {
+                            smol();
+                        }, interval);
+                    }
+                });
+            };
 
-        setTimeout(() => {
-            if (sloting) {
+            const doublecheck = setTimeout(() => {
                 client.off('messageUpdate', updateSlotListener);
                 startCollector();
-            }
-        }, 10000);
+            }, 10000);
 
-        client.on('messageUpdate', updateSlotListener);
+            client.on('messageUpdate', updateSlotListener);
+        });
     }
 }

--- a/utils/function/inventory.js
+++ b/utils/function/inventory.js
@@ -14,6 +14,7 @@ async function inventory(client, channel) {
     if (client.global.captchadetected ||
         client.global.paused ||
         client.global.inventory) return;
+    channel.sendTyping();
     client.global.inventory = true;
     client.logger.info("Farm", "Inventory", `Paused: ${client.global.inventory}! Getting Inventory ...`);
     let id;

--- a/utils/function/luck.js
+++ b/utils/function/luck.js
@@ -1,4 +1,5 @@
 const commandrandomizer = (arr) => arr[Math.floor(Math.random() * arr.length)];
+const getrand = (min, max) => Math.random() * (max - min) + min;
 
 module.exports = async (client, message) => {
     let channel = client.channels.cache.get(client.basic.commandschannelid);
@@ -18,7 +19,11 @@ async function pray(client, channel) {
           ) {
         await client.delay(16000);
     }
+    channel.sendTyping();
     let content;
+    let interval = getrand(
+        client.config.interval.pray.min,
+        client.config.interval.pray.max);
     if (client.basic.commands.tomain) {
         content = commandrandomizer(["owo", client.config.settings.owoprefix]) +
                     "pray <@" + client.config.main.userid + ">";
@@ -39,7 +44,7 @@ async function pray(client, channel) {
     
     setTimeout(() => {
         pray(client, channel);
-    }, 336000);
+    }, interval);
 }
 
 async function curse(client, channel) {
@@ -50,7 +55,11 @@ async function curse(client, channel) {
           ) {
         await client.delay(16000);
     }
+    channel.sendTyping();
     let content;
+    let interval = getrand(
+        client.config.interval.pray.min,
+        client.config.interval.pray.max);
     if (client.basic.commands.tomain) {
         content = commandrandomizer(["owo", client.config.settings.owoprefix]) +
                     "curse  <@" + client.config.main.userid + ">";
@@ -71,5 +80,5 @@ async function curse(client, channel) {
     
     setTimeout(() => {
         curse(client, channel);
-    }, 336000);
+    }, interval);
 }

--- a/utils/function/quest.js
+++ b/utils/function/quest.js
@@ -1,9 +1,10 @@
 const fs = require("fs");
 let type = "single";
-let mainclient, extraclient, mainSender, extraSender;;
+let mainclient, extraclient, mainSender, extraSender;
 let mainready = false;
 let extraready = false;
 const commandrandomizer = (arr) => arr[Math.floor(Math.random() * arr.length)];
+const getrand = (min, max) => Math.random() * (max - min) + min;
 
 module.exports = async (client, message) => {
     let channel;
@@ -56,6 +57,7 @@ async function questHandler(client, channel, mainSender, extraSender) {
     
     client.logger.info("Farm", "Questing", "Getting quest...");
     let id;
+    channel.sendTyping();
     channel
         .send({
             content: `${commandrandomizer([
@@ -147,6 +149,8 @@ async function questHandler(client, channel, mainSender, extraSender) {
             if (questcontent.includes("You finished all of your quests!")) {
                 client.logger.info("Farm", "Quest", "All quest completed!");
                 client.global.quest.title = "All quest completed!";
+                client.global.quest.reward = "";
+                client.global.quest.progress = "";
             } else {
                 let selectedQuest = false;
                 for (const quest of quests) {
@@ -185,8 +189,8 @@ async function questHandler(client, channel, mainSender, extraSender) {
                                     selectedQuest = true;
                                     break;
                                 case quest.title.includes("Receive a cookie from") &&
-                                     (!mainclient.global.temp.usedcookie &&
-                                      !extraclient.global.temp.usedcookie):
+                                     (mainclient.global.temp.usedcookie == false &&
+                                      extraclient.global.temp.usedcookie == false):
                                     questCookie(client, channel, quest, mainSender, extraSender);
                                     selectedQuest = true;
                                     break;
@@ -249,14 +253,16 @@ async function questOwO(client, channel, quest) {
                client.global.paused)
             await client.delay(16000);
         
+        channel.sendTyping();
         channel.send({
             content: `${commandrandomizer(["owo", "Owo", "owO", "OwO"])}`
         }).then(async () => {
             quest.pro1++;
             client.global.quest.progress = quest.pro1 + " / " + quest.pro2;
         });
-        await client.delay(12345);
+        await client.delay(getrand(12000, 16000));
     }
+    client.global.quest.progress = "Completed!";
     
     setTimeout(() => {
         questHandler(client, channel)
@@ -269,6 +275,7 @@ async function questGamble(client, channel, quest) {
                client.global.paused)
             await client.delay(16000);
         
+        channel.sendTyping();
         channel.send({
             content: `${commandrandomizer(["owo", "Owo", "owO", "OwO"])}` + 
                      `${commandrandomizer(["cf", "coinflip"])}` +
@@ -277,8 +284,9 @@ async function questGamble(client, channel, quest) {
             quest.pro1++;
             client.global.quest.progress = quest.pro1 + " / " + quest.pro2;
         });
-        await client.delay(12345);
+        await client.delay(getrand(12000, 16000));
     }
+    client.global.quest.progress = "Completed!";
     
     setTimeout(() => {
         questHandler(client, channel)
@@ -291,14 +299,16 @@ async function questActionOther(client, channel, quest) {
                client.global.paused)
             await client.delay(16000);
         
+        channel.sendTyping();
         channel.send({
             content: `${commandrandomizer(["owo", "Owo", "owO", "OwO"])} hug <@408785106942164992>`
         }).then(async () => {
             quest.pro1++;
             client.global.quest.progress = quest.pro1 + " / " + quest.pro2;
         });
-        await client.delay(12345);
+        await client.delay(getrand(12000, 16000));
     }
+    client.global.quest.progress = "Completed!";
     
     setTimeout(() => {
         questHandler(client, channel)
@@ -322,6 +332,7 @@ async function questCurse(client, channel, quest, mainSender, extraSender) {
                    client.global.paused)
                 await client.delay(16000);
             
+            mainSender.sendTyping();
             mainSender.send({ //so it will need extra to curse to main
                 content: `${commandrandomizer(["owo", client.config.settings.owoprefix])} curse <@${mainclient.basic.userid}>`
             }).then(async () => {
@@ -341,6 +352,7 @@ async function questCurse(client, channel, quest, mainSender, extraSender) {
                    client.global.paused)
                 await client.delay(16000);
             
+            extraSender.sendTyping();
             extraSender.send({
                 content: `${commandrandomizer(["owo", client.config.settings.owoprefix])} curse <@${extraclient.basic.userid}>`
             }).then(async () => {
@@ -351,9 +363,10 @@ async function questCurse(client, channel, quest, mainSender, extraSender) {
         }
         if (resetProp) client.config.main.commands.curse = true;
     }
+    client.global.quest.progress = "Completed!";
     
     setTimeout(() => {
-        questHandler(client, channel)
+        questHandler(client, channel, mainSender, extraSender)
     }, 16000);
 }
 
@@ -369,6 +382,7 @@ async function questPray(client, channel, quest, mainSender, extraSender) {
                    client.global.paused)
                 await client.delay(16000);
             
+            mainSender.sendTyping();
             mainSender.send({
                 content: `${commandrandomizer(["owo", client.config.settings.owoprefix])} pray <@${mainclient.basic.userid}>`
             }).then(async () => {
@@ -388,6 +402,7 @@ async function questPray(client, channel, quest, mainSender, extraSender) {
                    client.global.paused)
                 await client.delay(16000);
             
+            extraSender.sendTyping();
             extraSender.send({
                 content: `${commandrandomizer(["owo", client.config.settings.owoprefix])} pray <@${extraclient.basic.userid}>`
             }).then(async () => {
@@ -398,13 +413,15 @@ async function questPray(client, channel, quest, mainSender, extraSender) {
         }
         if (resetProp) client.config.main.commands.pray = true;
     }
+    client.global.quest.progress = "Completed!";
     
     setTimeout(() => {
-        questHandler(client, channel)
+        questHandler(client, channel, mainSender, extraSender)
     }, 16000);
 }
 
 async function questBattle(client, channel, quest, mainSender, extraSender) {
+    await client.delay(16000);
     let resetProp = false;
     if (client.global.type == "Main") {
         if (client.basic.commands.battle) {
@@ -416,10 +433,12 @@ async function questBattle(client, channel, quest, mainSender, extraSender) {
                    client.global.paused)
                 await client.delay(16000);
             
+            channel.sendTyping();
             channel.send({
                 content: `${commandrandomizer(["owo", client.config.settings.owoprefix])} ${commandrandomizer(["battle", "b"])} <@${extraclient.basic.userid}>`
             }).then(async () => {
                 await client.delay(4000);
+                mainSender.sendTyping();
                 mainSender.send({
                     content: `${commandrandomizer(["owo", client.config.settings.owoprefix])}ab`
                 });
@@ -439,10 +458,12 @@ async function questBattle(client, channel, quest, mainSender, extraSender) {
                    client.global.paused)
                 await client.delay(16000);
             
+            channel.sendTyping();
             channel.send({
                 content: `${commandrandomizer(["owo", client.config.settings.owoprefix])} battle <@${mainclient.basic.userid}>`
             }).then(async () => {
                 await client.delay(4000);
+                channel.sendTyping();
                 extraSender.send({
                     content: `${commandrandomizer(["owo", client.config.settings.owoprefix])}ab`
                 });
@@ -453,9 +474,10 @@ async function questBattle(client, channel, quest, mainSender, extraSender) {
         }
         if (resetProp) client.basic.commands.battle = true;
     }
+    client.global.quest.progress = "Completed!";
     
     setTimeout(() => {
-        questHandler(client, channel)
+        questHandler(client, channel, mainSender, extraSender)
     }, 16000);
 }
 
@@ -485,9 +507,10 @@ async function questCookie(client, channel, quest, mainSender, extraSender) {
             client.global.quest.progress = quest.pro1 + " / " + quest.pro2;
         });
     }
+    client.global.quest.progress = "Completed!";
     
     setTimeout(() => {
-        questHandler(client, channel)
+        questHandler(client, channel, mainSender, extraSender)
     }, 16000);
 }
 
@@ -498,6 +521,7 @@ async function questActionMe(client, channel, quest, mainSender, extraSender) {
                    client.global.paused)
                 await client.delay(16000);
             
+            mainSender.sendTyping();
             mainSender.send({
                 content: `${commandrandomizer(["owo", client.config.settings.owoprefix])} ${commandrandomizer(["hug", "kiss"])} <@${mainclient.basic.userid}>`
             }).then(async () => {
@@ -512,6 +536,7 @@ async function questActionMe(client, channel, quest, mainSender, extraSender) {
                    client.global.paused)
                 await client.delay(16000);
             
+            extraSender.sendTyping();
             extraSender.send({
                 content: `${commandrandomizer(["owo", client.config.settings.owoprefix])} ${commandrandomizer(["hug", "kiss"])} <@${extraclient.basic.userid}>`
             }).then(async () => {
@@ -521,8 +546,9 @@ async function questActionMe(client, channel, quest, mainSender, extraSender) {
             await client.delay(16000);
         }
     }
+    client.global.quest.progress = "Completed!";
     
     setTimeout(() => {
-        questHandler(client, channel)
+        questHandler(client, channel, mainSender, extraSender)
     }, 16000);
 }

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,10 +1,20 @@
 let reallog = [];
+let fulllog = [];
 let client, extrac;
 module.exports = (uwu) => { //plz change it when upload, u will remember it, right?
     let logger = [];
-    let length = uwu ? uwu.config.settings.loglength : 16;
+    let length = uwu ? uwu.config.settings.logging.loglength : 16;
     if (uwu.global.type == "Main") client = uwu;
     else extrac = uwu;
+    let exitlog = uwu.config.settings.logging.showlogbeforeexit && uwu.config.settings.logging.newlog;
+    process.on('SIGINT', () => {
+        if (exitlog) {
+            for (const logs of fulllog) console.log(logs);
+            console.log("//END OF LOG//");
+        }
+        process.exit(0);
+    });
+            
     
     function info(type, module, result = "") {
         logging(type, module, result, client.chalk.green);
@@ -21,12 +31,13 @@ module.exports = (uwu) => { //plz change it when upload, u will remember it, rig
     function logging(type, module, result, color) {
         const logMessage = `${client.chalk.white(`[${new Date().toLocaleTimeString()}]`)} ` +
                            `${client.chalk.blue(client.chalk.bold(type))}` +
-                           `${(type == "Bot" || type == "Updater") && (module != "Startup" || module != "Captcha") ? "" : //idk why i put this on
+                           `${(type == "Bot" || type == "Updater") && (module != "Startup" && module != "Captcha") ? "" : //idk why i put this on
                            `${client.chalk.white(" >> ")}${client.chalk.cyan(client.chalk.bold(uwu.global.type))}`} > ` +
                            `${client.chalk.magenta(module)} > ` +
                            `${color(result)}`;
 
         reallog.push(logMessage);
+        if (exitlog) fulllog.push(logMessage);
         if (reallog.length >= length) reallog.shift();
         showlog(reallog);
     }
@@ -77,7 +88,7 @@ module.exports = (uwu) => { //plz change it when upload, u will remember it, rig
             }
         }
         
-        if (uwu.config.extra.enable && extrac && uwu.config.settings.newlog) {
+        if (uwu.config.extra.enable && extrac && uwu.config.settings.logging.newlog) {
             console.clear();
             console.log(
 `╔══════════╦═══════════════════════╦════════════════════════════════════════════════
@@ -93,7 +104,7 @@ module.exports = (uwu) => { //plz change it when upload, u will remember it, rig
 ╚══════════╩═══════════════════════╩════════════════════════════════════════════════
 >>> Log`);
             for (const logs of reallog) console.log(logs);
-        } else if (uwu.config.settings.newlog) {
+        } else if (uwu.config.settings.logging.newlog) {
             console.clear();
             console.log(
 `╔══════════════════════╦══════════╦═══════════════════════════════════════════════

--- a/utils/mainHandler.js
+++ b/utils/mainHandler.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const commandrandomizer = (arr) => arr[Math.floor(Math.random() * arr.length)];
+const getrand = (min, max) => Math.random() * (max - min) + min;
 
 module.exports = async (client, message) => {
     if (client.global.paused || client.global.captchadetected) return;
@@ -27,10 +28,13 @@ module.exports = async (client, message) => {
     else client.global.quest.title = "Quest not enabled";
     
     await client.delay(16000);
-    if (client.basic.commands.animals) sell(client,
-        channel,
-        client.config.animals.type.sell ? "sell" : "sacrifice",
-        client.global.temp.animaltype);
+    if (client.basic.commands.animals) 
+        sell(
+            client,
+            channel,
+            client.config.animals.type.sell ? "sell" : "sacrifice",
+            client.global.temp.animaltype
+        );
     
     await client.delay(32000);
     require("./function/luck.js")(client, message);
@@ -39,6 +43,7 @@ module.exports = async (client, message) => {
 async function checklist(client, channel) {
     if (client.global.captchadetected || client.global.paused) return;
     let id;
+    channel.sendTyping();
     await channel
         .send({
             content: `${commandrandomizer([
@@ -241,7 +246,13 @@ async function checklist(client, channel) {
 }
 
 async function sell(client, channel, choose, types) {
-    if (client.global.captchadetected || client.global.paused) return;
+    if (client.global.captchadetected || client.global.paused) {
+        setTimeout(() => {
+            sell(client, channel, choose, types);
+        }, 16000);
+        return;
+    }
+    channel.sendTyping();
     await channel
         .send({
             content: `${commandrandomizer([
@@ -249,4 +260,7 @@ async function sell(client, channel, choose, types) {
                 client.config.settings.owoprefix,
             ])} ${choose} ${types}`,
         });
+    setTimeout(() => {
+        sell(client, channel, choose, types);
+    }, getrand(client.config.interval.animals.min, client.config.interval.animals.max));
 }


### PR DESCRIPTION
 - Bring the interval back to avoid captcha (still effective)
 - Change recall mechanic from `setInterval()` to check then recall whole function to work with interval again (idk how discordjs handle network error but at this moment i do not need the anti-anti-crash :D)
 - Typing i...inc... wut? Idk the line show that you are typing is back :D
 - Add a small entry to show all log when exit (with new log)
 - Bug fix:
   - Fix gamble sometime cannot recall itself
   - Fix questing do not pass the value when recall
   - Fix duplicating `hunt()`
   - Fix if someone use `start` after a captcha it will run more farm space (ok ik it will make the `resume` useless but nvm)